### PR TITLE
Basic portal funneling

### DIFF
--- a/lua/autorun/sh_portal_funnel.lua
+++ b/lua/autorun/sh_portal_funnel.lua
@@ -10,6 +10,8 @@ local attractionRadius = 480
 // of the portal, then do not funnel. We wouldn't want to funnel a player
 // into a portal that they are not expressing any intent to enter.
 local angleRange = math.pi / 4
+// currently uncapped. the option is there
+local speedCap = -1
 hook.Add("Move", "sp_portal_funnel", function(ply, move)
 
 	local vel = move:GetVelocity()
@@ -38,6 +40,9 @@ hook.Add("Move", "sp_portal_funnel", function(ply, move)
 			local towards = (portal:GetPos() - ply:GetPos()):GetNormalized() * mag
 			local power = attractionPower
 			if (move:GetSideSpeed() > 0) then power = attractionPowerStrafing end
+			if (speedCap > 0) then
+				power = math.min(power, speedCap / mag)
+			end
 			local newVel = vel * (1 - power) + towards * power
 			move:SetVelocity(newVel)
 		end

--- a/lua/autorun/sh_portal_funnel.lua
+++ b/lua/autorun/sh_portal_funnel.lua
@@ -1,0 +1,43 @@
+
+// possible todo: make these convars?
+
+// what percentage of the speed to convert into funneling
+local attractionPower = 0.2
+// at what distance to stop looking for portals to funnel into
+local attractionRadius = 480
+// if the current direction is this much offset from the inward direction
+// of the portal, then do not funnel. We wouldn't want to funnel a player
+// into a portal that they are not expressing any intent to enter.
+local angleRange = math.pi / 4
+hook.Add("Move", "sp_portal_funnel", function(ply, move)
+
+	local vel = move:GetVelocity()
+	local threshold = math.pow(ply:GetRunSpeed(), 2)
+	local magSqr = vel:LengthSqr()
+	local portal = NULL
+	// Only if the player is traveling at least their run speed.
+	// At lower speeds, players aren't really going to need funneling.
+	// This also allows us to elegantly sidestep some issues.
+	if (magSqr >= threshold) then
+		local found = ents.FindInSphere(ply:GetPos(), attractionRadius)
+		for _,ent in ipairs(found) do
+			if (ent:GetClass() == "seamless_portal") then
+				portal = ent
+				break
+			end
+		end
+	end
+	if IsValid(portal) then
+		local mag = math.sqrt(magSqr)
+		local inward = -portal:GetUp()
+		local angle = math.acos((vel.x * inward.x + vel.y * inward.y + vel.z * inward.z) / mag)
+		if (math.abs(angle) <= angleRange) then
+			// Crucially, we are not adding any energy here. Magnitude stays
+			// the same before and after.
+			local towards = (portal:GetPos() - ply:GetPos()):GetNormalized() * mag
+			local newVel = vel * (1 - attractionPower) + towards * attractionPower
+			move:SetVelocity(newVel)
+		end
+	end
+
+end ) 

--- a/lua/autorun/sh_portal_funnel.lua
+++ b/lua/autorun/sh_portal_funnel.lua
@@ -1,16 +1,16 @@
 
-// possible todo: make these convars?
+-- possible todo: make these convars?
 
-// what percentage of the speed to convert into funneling
+-- what percentage of the speed to convert into funneling
 local attractionPower = 0.2
 local attractionPowerStrafing = 0.02
-// at what distance to stop looking for portals to funnel into
+-- at what distance to stop looking for portals to funnel into
 local attractionRadius = 480
-// if the current direction is this much offset from the inward direction
-// of the portal, then do not funnel. We wouldn't want to funnel a player
-// into a portal that they are not expressing any intent to enter.
+-- if the current direction is this much offset from the inward direction
+-- of the portal, then do not funnel. We wouldn't want to funnel a player
+-- into a portal that they are not expressing any intent to enter.
 local angleRange = math.pi / 4
-// currently uncapped. the option is there
+-- currently uncapped. the option is there
 local speedCap = -1
 hook.Add("Move", "sp_portal_funnel", function(ply, move)
 
@@ -18,9 +18,9 @@ hook.Add("Move", "sp_portal_funnel", function(ply, move)
 	local threshold = math.pow(ply:GetRunSpeed(), 2)
 	local magSqr = vel:LengthSqr()
 	local portal = NULL
-	// Only if the player is traveling at least their run speed.
-	// At lower speeds, players aren't really going to need funneling.
-	// This also allows us to elegantly sidestep some issues.
+	-- Only if the player is traveling at least their run speed.
+	-- At lower speeds, players aren't really going to need funneling.
+	-- This also allows us to elegantly sidestep some issues.
 	if (magSqr >= threshold) then
 		local found = ents.FindInSphere(ply:GetPos(), attractionRadius)
 		for _,ent in ipairs(found) do
@@ -35,8 +35,8 @@ hook.Add("Move", "sp_portal_funnel", function(ply, move)
 		local inward = -portal:GetUp()
 		local angle = math.acos((vel.x * inward.x + vel.y * inward.y + vel.z * inward.z) / mag)
 		if (math.abs(angle) <= angleRange) then
-			// Crucially, we are not adding any energy here. Magnitude stays
-			// the same before and after.
+			-- Crucially, we are not adding any energy here. Magnitude stays
+			-- the same before and after.
 			local towards = (portal:GetPos() - ply:GetPos()):GetNormalized() * mag
 			local power = attractionPower
 			if (move:GetSideSpeed() > 0) then power = attractionPowerStrafing end

--- a/lua/autorun/sh_portal_funnel.lua
+++ b/lua/autorun/sh_portal_funnel.lua
@@ -10,8 +10,6 @@ local attractionRadius = 480
 -- of the portal, then do not funnel. We wouldn't want to funnel a player
 -- into a portal that they are not expressing any intent to enter.
 local angleRange = math.pi / 4
--- currently uncapped. the option is there
-local speedCap = -1
 hook.Add("Move", "sp_portal_funnel", function(ply, move)
 
 	local vel = move:GetVelocity()
@@ -40,7 +38,8 @@ hook.Add("Move", "sp_portal_funnel", function(ply, move)
 			local towards = (portal:GetPos() - ply:GetPos()):GetNormalized() * mag
 			local power = attractionPower
 			if (move:GetSideSpeed() > 0) then power = attractionPowerStrafing end
-			if (speedCap > 0) then
+			local speedCap = ply:GetRunSpeed()
+			if (speedCap > 0 and speedCap < mag) then
 				power = math.min(power, speedCap / mag)
 			end
 			local newVel = vel * (1 - power) + towards * power

--- a/lua/autorun/sh_portal_funnel.lua
+++ b/lua/autorun/sh_portal_funnel.lua
@@ -3,6 +3,7 @@
 
 // what percentage of the speed to convert into funneling
 local attractionPower = 0.2
+local attractionPowerStrafing = 0.02
 // at what distance to stop looking for portals to funnel into
 local attractionRadius = 480
 // if the current direction is this much offset from the inward direction
@@ -35,7 +36,9 @@ hook.Add("Move", "sp_portal_funnel", function(ply, move)
 			// Crucially, we are not adding any energy here. Magnitude stays
 			// the same before and after.
 			local towards = (portal:GetPos() - ply:GetPos()):GetNormalized() * mag
-			local newVel = vel * (1 - attractionPower) + towards * attractionPower
+			local power = attractionPower
+			if (move:GetSideSpeed() > 0) then power = attractionPowerStrafing end
+			local newVel = vel * (1 - power) + towards * power
 			move:SetVelocity(newVel)
 		end
 	end


### PR DESCRIPTION
Feel free to reject. This makes riskier portal maneuvers a little more bearable. Portal funneling existed in the Portal games for the same reason of improving the gameplay experience, which I believe this accomplishes. I tweaked the values until I got something I liked, but it might not be what you want. It only applies when moving relatively fast, and when somewhat facing the target portal. Sometimes the result of this funneling can look a little bit ridiculous, as it can in the Portal games, however those occurrences are few and far between. The goal isn't to turn you into a homing missile, but rather reduce moments where you just barely clip the edge of a portal. I urge you to test it out a bit before merging.

Maybe this will allow your 2 minute record to be broken? ;)