### PR TITLE
fix: local srcds server not using ping comp fix, causing 1 frame yaw …

### DIFF
--- a/lua/autorun/sh_portal_movement.lua
+++ b/lua/autorun/sh_portal_movement.lua
@@ -30,7 +30,7 @@ local function updateCalcViews(finalPos, finalVel)
 		angle.r = angle.r * addAngle
 
 		-- position ping compensation -- using real velocity for getting the actual feeling of the player position rather than guessing
-		if freezePly and ply:Ping() > 5 then
+		if freezePly and ply:Ping() >= 5 then
 			finalPos = finalPos + finalVel * FrameTime()
 			SeamlessPortals.DrawPlayerInView = true
 		else


### PR DESCRIPTION
Scratched my head at this for a couple hours.

It was working fine in singleplayer, perfectly smooth, but as soon as I entered a portal on a local scrds server, there was a 1 frame where it was +180 yaw for a singular frame (not tick) which really ruined the smooth effect that was so carefully and thoughtfully obtained by the rest of the codebase. Gadly it's a simple fix.